### PR TITLE
[next] target next@6.0.0

### DIFF
--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for next 5.0
+// Type definitions for next 6.0
 // Project: https://github.com/zeit/next.js
 // Definitions by: Drew Hays <https://github.com/dru89>
 //                 Brice BERNARD <https://github.com/brikou>


### PR DESCRIPTION
`next@6.0.0` is out, so let's change the target version to it.